### PR TITLE
Global style setup

### DIFF
--- a/css/media-queries.css
+++ b/css/media-queries.css
@@ -1,5 +1,5 @@
 /* Global */
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap');
 
 * {
     font-family: 'Source Sans Pro', sans-serif;

--- a/css/media-queries.css
+++ b/css/media-queries.css
@@ -1,7 +1,37 @@
 /* Global */
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap');
+
+* {
+    font-family: 'Source Sans Pro', sans-serif;
+}
+h1, h2, p {
+    margin: .5rem;
+}
+h1 {
+    font-size: 4rem;
+}
+.sub-section {
+    font-style: italic;
+}
+/*  This styling makes the img element resize automatically depending on screen size.
+    As we start working on the desktop styling it may need to be changed. */
+img {
+    max-width: 100%;
+    height: auto;
+    margin: auto;
+}
+footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 10vh .5em 2vh .5em;
+}
+footer>p {
+    margin: 0;
+}
 
 /* Mobile */
-@media screen and (max-width: 992px) {
+@media screen and (max-width: 768px) {
     .hidden-on-desktop a{
         /*style*/
         background: #dff;
@@ -30,7 +60,7 @@
 }
 
 /* Desktop */
-@media screen and (min-width: 992px) {
+@media screen and (min-width: 768px) {
     .hidden-on-desktop {
         display: none;
     }

--- a/css/media-queries.css
+++ b/css/media-queries.css
@@ -10,6 +10,9 @@ h1, h2, p {
 h1 {
     font-size: 4rem;
 }
+nav ul {
+    padding: 0;
+}
 .sub-section {
     font-style: italic;
 }


### PR DESCRIPTION
Finished most of the styling needed that applies to both the mobile and desktop layouts of the page.

**Important** I forgot to acknowledge in my first commit in this branch that I changed the resolution breakpoint for the media query from 992 back to 768. The pictures provided for reference in the curriculum seem to line up more around one being < 768 and the other being > 768, at least, if the placeholder image element's visible dimensions are accurate. If you disagree and prefer another breakpoint, I won't complain. 

I think we're about ready to start working on the desktop style next. There are still little bits of weird margins and alignments but minor stuff like that is easier to iron out when the big stuff is out of the way I think. We'll get it sorted out!